### PR TITLE
feat: v1 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Built for the *Google Chrome Built-in AI Challenge 2025*.
 ## Features
 
 - **Section aware summaries**  
-  Detects page sections (H1–H3) and produces concise, markdown bullet points per section.
+  Detects page sections (H1–H4, with a fallback to main-page text) and produces concise, markdown bullet points per section — plus an **Overview**.
 
 - **Multilingual output**  
   Choose your language (English, Hindi, Spanish, French). Translation uses the on device **Translator API** when available, with a **Prompt API** fallback.
 
 - **Flashcards in one click**  
-  Generates up to 8 Q↔A cards as JSON using the **Prompt API**, with CSV export.
+  Generates **8–24** Q↔A cards as JSON using the **Prompt API**, with CSV export.
 
 - **Ask about this page**  
   Short, sourced answers using *only* the extracted page text (no hallucinated facts).
@@ -107,7 +107,7 @@ The extension checks availability at runtime and gracefully falls back where pos
 - `scripting` – inject a tiny snippet for section detection and “Go to section”  
 - `storage` – save theme/language preferences  
 - `contextMenus` – right click “Explain selection”  
-- `host_permissions: ["http://*/*", "https://*/*"]` – read text of the page you’re summarizing
+- `host_permissions: ["<all_urls>"]` – read text of the page you’re summarizing (and optionally PDFs / file URLs)
 
 **Privacy:** StudyPilot runs entirely in your browser. No remote server is used for AI processing. See **[PRIVACY.md](./PRIVACY.md)**.
 
@@ -115,7 +115,9 @@ The extension checks availability at runtime and gracefully falls back where pos
 
 ## Troubleshooting
 
-- **“Unsupported page”** – works on `http(s)` pages. `chrome://`, `edge://`, PDFs, and some web apps may not expose readable text.  
+- **“Unsupported page”** – works on `http(s)` pages. `chrome://`, the Chrome Web Store, and some web apps may not expose readable text.  
+- **PDFs** – sometimes extractable (if text is selectable). Some PDFs will still be blank due to viewer/security limitations.  
+- **file:// pages** – requires enabling “Allow access to file URLs” for the extension in `chrome://extensions`.
 - **Model unavailable / activation** – click **Summarize** once to allow Chrome to initialize or download the on device model, then try again.  
 - **PDF dialog didn’t show** – some setups block programmatic print. Press `Ctrl/Cmd+P`.  
 - **Dark print preview** – your OS/browser print theme may default to dark. Switch to light before saving (known UX todo).

--- a/ai.js
+++ b/ai.js
@@ -5,7 +5,7 @@ async function makeSummarizer(opts = {}) {
     type: opts.type || 'key-points',
     format: 'markdown',
     length: opts.length || 'medium',
-    outputLanguage: 'en',                 // required by newer builds
+    outputLanguage: 'en',                 
     expectedInputLanguages: ['en'],
     monitor(m) {
       m.addEventListener('downloadprogress', e =>
@@ -14,7 +14,6 @@ async function makeSummarizer(opts = {}) {
     }
   };
 
-  // availability must match create() options
   const availability = await Summarizer.availability(options);
   if (availability === 'unavailable') return { error: 'SUMMARIZER_UNAVAILABLE' };
 
@@ -23,7 +22,6 @@ async function makeSummarizer(opts = {}) {
 }
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  // ⚡ ping handler so SW can verify this page is ready
   if (msg?.kind === 'AI_PING') { sendResponse({ ok: true }); return; }
 
   if (msg?.kind !== 'AI_DO') return;
@@ -44,5 +42,5 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     }
   })();
 
-  return true; // keep channel open for async work
+  return true; 
 });

--- a/content.js
+++ b/content.js
@@ -17,20 +17,18 @@
     cursor: 'pointer'
   });
 
-  // Safe send: works even if the extension was just reloaded
+ 
   function openPanelSafe() {
-    // if the extension context is gone (after reload), this will be falsey
     if (!chrome?.runtime?.id) return;
     try {
       const p = chrome.runtime.sendMessage({ kind: 'OPEN_PANEL' });
-      // avoid unhandled promise rejection from context invalidation
       if (p && typeof p.catch === 'function') p.catch(() => {});
-    } catch (_) { /* ignore */ }
+    } catch (_) {  }
   }
 
   btn.addEventListener('click', openPanelSafe);
 
-  // Re-attach if some SPA wipes the body
+ 
   const mo = new MutationObserver(() => {
     if (!document.getElementById('__studypilot_btn')) {
       document.body.appendChild(btn);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "StudyPilot — Learning Mode for the Web",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "description": "Summarize, translate, simplify, and quiz any page. On-device with Chrome built-in AI.",
   "permissions": ["storage", "sidePanel", "scripting", "activeTab", "contextMenus"],
   "host_permissions": ["<all_urls>"],

--- a/panel.css
+++ b/panel.css
@@ -1,11 +1,10 @@
 :root{
-  /* base = system auto (prefers-color-scheme) */
   --bg:#ffffff; --fg:#111827; --muted:#6b7280; --card:#f8fafc; --ring:#e5e7eb; --brand:#2563eb;
 }
 @media (prefers-color-scheme: dark){
   :root{ --bg:#0b0f16; --fg:#e5e7eb; --muted:#9aa3b2; --card:#121826; --ring:#1f2937; --brand:#3b82f6; }
 }
-/* explicit overrides */
+
 :root[data-theme="light"]{
   --bg:#ffffff; --fg:#111827; --muted:#6b7280; --card:#f8fafc; --ring:#e5e7eb; --brand:#2563eb;
 }
@@ -14,7 +13,7 @@
 }
 
 
-*{box-sizing:border-box} html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:14px/1.5 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+*{box-sizing:border-box} html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font:15px/1.65 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 
 .sp-header{display:flex;align-items:center;justify-content:space-between;padding:12px;border-bottom:1px solid var(--ring)}
 .sp-title{font-weight:700}
@@ -35,10 +34,10 @@
 .sp-sections{display:flex;flex-direction:column;gap:10px}
 .sp-card{border:1px solid var(--ring);border-radius:14px;background:var(--card);overflow:hidden}
 .sp-card__head{display:flex;justify-content:space-between;align-items:center;padding:10px 12px;background:transparent;border-bottom:1px solid var(--ring)}
-.sp-card__title{font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:70%}
+.sp-card__title{font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:75%}
 .sp-card__ctas{display:flex;gap:6px}
 .sp-link{border:1px solid var(--ring);background:transparent;color:var(--fg);border-radius:8px;padding:4px 8px;cursor:pointer}
-.sp-pre{white-space:pre-wrap;word-break:break-word;background:var(--card);margin:0;padding:12px}
+.sp-pre{white-space:pre-wrap;word-break:break-word;background:var(--card);margin:0;padding:12px;font-family:inherit;font-size:14px;line-height:1.6}
 
 .sp-row{display:flex;gap:8px;align-items:center}
 .sp-ask{display:flex;gap:8px}

--- a/panel.html
+++ b/panel.html
@@ -13,12 +13,15 @@
       <option value="es">Spanish</option>
       <option value="fr">French</option>
     </select>
+    <select id="sumLen" class="sp-select" title="Summary length">
+      <option value="short" selected>Short</option>
+      <option value="medium">Medium</option>
+      <option value="long">Long</option>
+    </select>
     <button id="refresh" class="sp-btn sp-btn--brand">Summarize</button>
     <button id="copyAll" class="sp-btn">Copy all</button>
-<button id="downloadMd" class="sp-btn">Download .md</button>
-<button id="downloadPdf" class="sp-btn">Download PDF</button>
-
-
+    <button id="downloadMd" class="sp-btn">Download .md</button>
+    <button id="downloadPdf" class="sp-btn">Download PDF</button>
   </div>
 </header>
 
@@ -39,6 +42,13 @@
 <section id="tab-flash" class="sp-tabpane">
   <div class="sp-row">
     <button id="flashGen" class="sp-btn sp-btn--brand">Generate Flashcards</button>
+    <select id="flashCount" class="sp-select" title="Number of flashcards">
+      <option value="8">8</option>
+      <option value="12">12</option>
+      <option value="16" selected>16</option>
+      <option value="20">20</option>
+      <option value="24">24</option>
+    </select>
     <button id="flashDownload" class="sp-btn" disabled>Download CSV</button>
   </div>
   <div id="flashList" class="sp-flashlist"></div>


### PR DESCRIPTION
## Summary
This PR ships StudyPilot v1 improvements:
- Overview appears at the top
- Better section-wise summarization (less mixing)
- Flashcards count configurable (>8)
- Improved readability (font sizing / less code-y)
- Copy button feedback (“Copied!”)
- Extension icon toggles side panel open/close
- Better handling of Built-in AI availability states
- Fix/clarify host permissions needed for extraction
- PDF extraction improvements (text layer when available)

Closes #<1>

## Changes
- UI: <brief list>
- Summarization: <brief list>
- Permissions/behavior: <brief list>

## How to test
1. `chrome://extensions` → Developer mode ON
2. Load unpacked → select repo folder
3. Open an article page (https)
4. Open StudyPilot side panel
5. Verify:
   - Overview card appears first
   - Summaries match headings
   - Flashcards generate for selected count
   - Copy shows “Copied!”
   - Clicking extension icon again closes side panel
6. Test language switching + image Q&A
7. Test on a PDF (selectable-text PDF)

## Notes
- Built-in AI may show `downloadable/downloading` depending on device; UI should guide user.
- Some pages cannot be accessed (chrome://, webstore); expected.
